### PR TITLE
Allow adding additional compiler and linker flags through environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,14 +98,16 @@ ifeq ($(shell uname -s),Darwin)
 endif
 
 INCLUDE := -I src
-LIBS := -lnymphrpc -lPocoNet -lPocoUtil -lPocoFoundation -lPocoJSON 
+LIBS := -lnymphrpc -lPocoNet -lPocoUtil -lPocoFoundation -lPocoJSON
+LIBS += $(LDFLAGS)
 
 ifeq ($(USYS),FreeBSD)
 	INCLUDE += -I /usr/local/include
 	LIBS += -L /usr/local/lib
 endif
 
-CXXFLAGS := $(INCLUDE) -g3 -std=c++17 -O0
+CXXFLAGS += $(INCLUDE) -g3 -std=c++17 -O0
+
 SHARED_FLAGS := -fPIC -shared -Wl,$(SONAME),$(LIBNAME)
 
 ifndef NPOCO


### PR DESCRIPTION
This is useful for example to tell the compiler where to find header files when not available in standard locations, and the linker where to find libraries when not available in standard locations.

I do wonder why the name `LIBS` is used rather than the more standard `LDFLAGS`. Would it be ok to just use `LDFLAGS` in the Makefile instead and do a simple `LDFLAGS += -lnymphrpc ...etc`?